### PR TITLE
[Feat] 깃허브 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,7 @@ dependencies {
 	// spring security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	testImplementation 'org.springframework.security:spring-security-test'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
 	//Jwt
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/src/main/java/LogITBackend/LogIT/DTO/UserRequestDTO.java
+++ b/src/main/java/LogITBackend/LogIT/DTO/UserRequestDTO.java
@@ -37,4 +37,14 @@ public class UserRequestDTO {
         @NotBlank(message = "비밀번호는 빈값일 수 없습니다.")
         private String password;
     }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class GithubSignUpRequestDTO {
+        private String providerId;
+        private String nickname;
+        private String githubAccessToken;
+    }
 }

--- a/src/main/java/LogITBackend/LogIT/config/security/JwtAuthenticationFilter.java
+++ b/src/main/java/LogITBackend/LogIT/config/security/JwtAuthenticationFilter.java
@@ -37,7 +37,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             "/users/signin/**",
             "/swagger-ui/**",
             "/v3/**",
-            "/users/admin/**",
+            "/users/admin/**"
+//            "/**"
 //            "/refresh", "/",
 //            "/index.html"
     };
@@ -45,6 +46,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final RedisTemplate<String, String> redisTemplate;
 
     private static void checkAuthorizationHeader(String header) {
+        log.info("-------------------#@@@@@------------------");
         if(header == null) {
             throw new CustomJwtException("토큰이 전달되지 않았습니다");
         } else if (!header.startsWith("Bearer ")) {
@@ -56,6 +58,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
         String requestURI = request.getRequestURI();
+        log.info("---------------$$$$$$------------------");
+        log.info("boolean: {}", PatternMatchUtils.simpleMatch(whitelist, requestURI));
+        log.info("requestURI: {}", requestURI);
         return PatternMatchUtils.simpleMatch(whitelist, requestURI);
     }
 
@@ -104,6 +109,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             String accessToken = JwtUtils.getTokenFromHeader(authHeader);
             jwtUtils.validateToken(accessToken); // 토큰 검증
             jwtUtils.isTokenBlacklisted(authHeader); // 🚨 블랙리스트 확인
+            log.info("------------------------------------------------------");
         } catch (Exception e) {
             Gson gson = new Gson();
             String json = "";

--- a/src/main/java/LogITBackend/LogIT/config/security/PasswordEncoderConfig.java
+++ b/src/main/java/LogITBackend/LogIT/config/security/PasswordEncoderConfig.java
@@ -1,0 +1,14 @@
+package LogITBackend.LogIT.config.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordEncoderConfig {
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/LogITBackend/LogIT/config/security/oauth/CustomAuthExceptionHandler.java
+++ b/src/main/java/LogITBackend/LogIT/config/security/oauth/CustomAuthExceptionHandler.java
@@ -1,0 +1,25 @@
+package LogITBackend.LogIT.config.security.oauth;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@Slf4j
+public class CustomAuthExceptionHandler implements AuthenticationFailureHandler {
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+                                        AuthenticationException exception) throws IOException, ServletException {
+        // 여기에 로그인 실패 후 처리할 내용을 작성하기!
+//        response.sendRedirect("/login-failure");
+        log.info("Fail!----------------");
+        log.info("❌ OAuth2 로그인 실패: {}", exception.getMessage()); // ✅ 여기!
+    }
+}

--- a/src/main/java/LogITBackend/LogIT/config/security/oauth/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/LogITBackend/LogIT/config/security/oauth/CustomOAuth2SuccessHandler.java
@@ -1,0 +1,82 @@
+package LogITBackend.LogIT.config.security.oauth;
+
+import LogITBackend.LogIT.domain.Users;
+import LogITBackend.LogIT.jwt.JwtUtils;
+import LogITBackend.LogIT.repository.UserRepository;
+import LogITBackend.LogIT.service.UserCommandService;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class CustomOAuth2SuccessHandler implements AuthenticationSuccessHandler {
+
+    @Value("${jwt.REDIRECT_URI}")
+    private String redirectUri; // 프론트엔드로 Jwt 토큰을 리다이렉트할 URI
+    @Value("${jwt.ACCESS_EXP_TIME}")
+    private int accessExpTime;
+    @Value("${jwt.REFRESH_EXP_TIME}")
+    private int refreshExpTime;
+    private final UserRepository userRepository;
+    private final UserCommandService userCommandService;
+    private final JwtUtils jwtUtils;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Override
+    @Transactional
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+                                        Authentication authentication) throws IOException, ServletException {
+        // 여기에 로그인 성공 후 처리할 내용을 작성하기!
+        DefaultOAuth2User oAuth2User = (DefaultOAuth2User) authentication.getPrincipal();
+        log.info("Suceess!---------------------");
+
+        // 프론트엔드에 보내줄 accessToken 및 refreshToken생성
+        Users getUser = userRepository.findByProviderId(oAuth2User.getName()).orElseThrow(null);
+        String accessToken = userCommandService.generateAccessToken(getUser.getId(), accessExpTime);
+        String key = "users:" + getUser.getId().toString();
+        String refreshToken = userCommandService.generateAndSaveRefreshToken(key, refreshExpTime);
+
+        // db에 인가처리할 accessToken저장 (개발자 테스트용)
+        getUser.updateAccessToken(accessToken);
+
+        // 프론트엔드에 accessToken과 refreshToken를 redirect url로 보내주기
+        // ✅ refreshToken 쿠키에 저장
+        Cookie cookie = new Cookie("refreshToken", refreshToken);
+        cookie.setHttpOnly(true);
+        cookie.setPath("/");
+        cookie.setMaxAge(7 * 24 * 60 * 60 * 2); // 14일
+        response.addCookie(cookie);
+
+        // ✅ accessToken 쿼리 파라미터로 전달
+        String redirectUrl = UriComponentsBuilder
+                .fromUriString(redirectUri)
+                .queryParam("accessToken", accessToken)
+                .build()
+                .toUriString();
+
+        response.sendRedirect(redirectUrl);
+    }
+
+//    private boolean isUser(DefaultOAuth2User oAuth2User) {
+//        return oAuth2User.getAuthorities().stream()
+//                .anyMatch(authority -> authority.getAuthority().equals("ROLE_USER"));
+//    }
+}
+

--- a/src/main/java/LogITBackend/LogIT/config/security/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/LogITBackend/LogIT/config/security/oauth/CustomOAuth2UserService.java
@@ -1,0 +1,59 @@
+package LogITBackend.LogIT.config.security.oauth;
+
+import LogITBackend.LogIT.DTO.UserRequestDTO;
+import LogITBackend.LogIT.converter.UserConverter;
+import LogITBackend.LogIT.domain.Users;
+import LogITBackend.LogIT.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+    private final UserRepository userRepository;
+
+    //    깃허브로 부터 받은 userRequest 데이터에 대한 후처리 되는 함수
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException{
+        log.info("^^^^^^^^^^^^^^^^^^^^^^^^^^^^");
+        log.info("getAccessToken: {}", userRequest.getAccessToken());
+        log.info("getAttributes: {}", super.loadUser(userRequest).getAttributes());
+        System.out.println("userRequest:"+userRequest);
+        System.out.println("getClientRegistraion:"+userRequest.getClientRegistration());  //client에 대한 정보들이 받아짐
+        System.out.println("getAccessToken:"+userRequest.getAccessToken().getTokenValue());
+        System.out.println("getAttributes:"+super.loadUser(userRequest).getAttributes()); //유저 정보를 받아옴
+
+        OAuth2User oAuth2User = super.loadUser(userRequest); // 실제 사용자 정보 요청
+
+        // 사용자 정보 map
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+
+        // 정보 추출
+        String providerId = String.valueOf(attributes.get("id"));
+        String nickname = (String) attributes.get("login");
+
+        Users existUser = userRepository.findByProviderId(providerId).orElse(null);
+
+        if (existUser == null) {
+            // user dto 생성해서 user저장
+            Users newUser = UserConverter.githubDatatoUsers(
+                    UserRequestDTO.GithubSignUpRequestDTO.builder()
+                            .providerId(providerId)
+                            .nickname(nickname)
+                            .githubAccessToken(userRequest.getAccessToken().getTokenValue())
+                            .build()
+            );
+            userRepository.save(newUser);
+        }
+
+        return oAuth2User;
+    }
+}

--- a/src/main/java/LogITBackend/LogIT/converter/UserConverter.java
+++ b/src/main/java/LogITBackend/LogIT/converter/UserConverter.java
@@ -14,6 +14,13 @@ public class UserConverter {
 //                .loginType(LoginType.REGULAR)
                 .build();
     }
+    public static Users githubDatatoUsers(UserRequestDTO.GithubSignUpRequestDTO request) {
+        return Users.builder()
+                .providerId(request.getProviderId())
+                .nickname(request.getNickname())
+                .githubAccesstoken(request.getGithubAccessToken())
+                .build();
+    }
     public static UserResponseDTO.UserSignUpResultDTO toUserSignUpResultDTO(Users users) {
         return UserResponseDTO.UserSignUpResultDTO.builder()
                 .userId(users.getId())

--- a/src/main/java/LogITBackend/LogIT/domain/Users.java
+++ b/src/main/java/LogITBackend/LogIT/domain/Users.java
@@ -59,6 +59,12 @@ public class Users extends BaseEntity {
 
     private LocalDateTime inactiveDate;
 
+    private String providerId;
+
+    private String githubAccesstoken;
+
+    private String accesstoken;
+
     // 로그인 관련
 //    private LocalDateTime lastLogin;
 
@@ -70,5 +76,9 @@ public class Users extends BaseEntity {
 
     public void encodePassword(String password) {
         this.password = password;
+    }
+
+    public void updateAccessToken(String accessToken) {
+        this.accesstoken = accessToken;
     }
 }

--- a/src/main/java/LogITBackend/LogIT/repository/UserRepository.java
+++ b/src/main/java/LogITBackend/LogIT/repository/UserRepository.java
@@ -11,4 +11,5 @@ public interface UserRepository extends JpaRepository<Users, Long> {
     @Override
     Optional<Users> findById(Long id);
     Optional<Users> findByUsername(String username);
+    Optional<Users> findByProviderId(String providerId);
 }

--- a/src/main/java/LogITBackend/LogIT/service/UserCommandService.java
+++ b/src/main/java/LogITBackend/LogIT/service/UserCommandService.java
@@ -7,4 +7,6 @@ import LogITBackend.LogIT.domain.Users;
 public interface UserCommandService {
     Users signUp(UserRequestDTO.SignUpRequestDTO request);
     UserResponseDTO.UserSignInResultDTO signIn(UserRequestDTO.SignInRequestDTO request);
+    String generateAccessToken(Long userId, int accessExpTime);
+    String generateAndSaveRefreshToken(String key, int refreshExpTime);
 }

--- a/src/main/java/LogITBackend/LogIT/service/UserCommandServiceImpl.java
+++ b/src/main/java/LogITBackend/LogIT/service/UserCommandServiceImpl.java
@@ -60,7 +60,7 @@ public class UserCommandServiceImpl implements UserCommandService {
         return UserConverter.toUserSignInResultDTO(getUser, accessToken, refreshToken);
     }
 
-    private String generateAccessToken(Long userId, int accessExpTime) {
+    public String generateAccessToken(Long userId, int accessExpTime) {
         // 인증 완료 후 jwt토큰(accessToken) 생성
         Map<String, Object> valueMap = Map.of(
                 "userId", userId // String으로 저장??? 그래서 SecurityUtil에서 Long으로 타입변환 해주나?
@@ -68,7 +68,7 @@ public class UserCommandServiceImpl implements UserCommandService {
         return jwtUtils.generateToken(valueMap, accessExpTime);
     }
 
-    private String generateAndSaveRefreshToken(String key, int refreshExpTime) {
+    public String generateAndSaveRefreshToken(String key, int refreshExpTime) {
         // 인증 완료 후 jwt토큰(refreshToken) 생성
         String refreshToken = jwtUtils.generateToken(Collections.emptyMap(), refreshExpTime);
         redisTemplate.opsForValue().set(key, refreshToken, refreshExpTime, TimeUnit.MINUTES);


### PR DESCRIPTION
## #️⃣연관된 이슈
> #18

## 📝작업 내용
> 깃허브 로그인 구현
> 프론트엔드에서 받은 authorization code를 통해 accesstoken를 받아오고 accesstoken으로 깃허브 리소스 서버에서 유저 정보 받아오기, 이는 모두 Spring Security로 처리 받아온 유저 정보로 회원가입 로그인 처리
> 회원가입 시 유저의 고유ID(providerId), 닉네임, PAT(깃허브가 제공하는 토큰) 자체 db에 저장

## 🔎코드 설명
> Spring Security(oauth-client)를 사용해 깃허브 인증 서버와 리소스 서버에서 각각 access token과 사용자 정보 가져오기
CustomOAuth2UserService
CustommOAuth2SuccessHandler
CustomAuthExceptionHandler
위 3개의 클래스 구현 후 SecurityConfig에 등록

## 💬고민사항 및 리뷰 요구사항 (Optional)
> x

## 비고 (Optional)
> x
