### PR TITLE
[Refactor] workflow파일(main.yml)의 ubuntu버전을 ec2의 ubuntu버전인 22.04로 변경

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       ## jdk setting
       - uses: actions/checkout@v3


### PR DESCRIPTION
## #️⃣연관된 이슈
> #46

## 📝작업 내용
> workflow파일(main.yml)의 ubuntu버전을 ec2의 ubuntu버전인 22.04로 변경

## 🔎코드 설명
> workflow파일(main.yml)의 ubuntu버전(20.04)을 ec2의 ubuntu버전인 22.04로 변경

## 💬고민사항 및 리뷰 요구사항 (Optional)
> x

## 비고 (Optional)
> x
